### PR TITLE
[BUGFIX] Correction Of Ad Implementation And Addition Of Ad Manager Util

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,5 +67,6 @@
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="ca-app-pub-5675914922459331~4542834527"/>
+<!--   Test App ID     -->
     </application>
 </manifest>

--- a/app/src/main/java/com/example/tempo/ui/BaseBottomNavActivity.java
+++ b/app/src/main/java/com/example/tempo/ui/BaseBottomNavActivity.java
@@ -3,16 +3,26 @@ package com.example.tempo.ui;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.util.Log;
+import android.view.ViewGroup;
+import android.widget.RelativeLayout;
 
 import androidx.annotation.IdRes;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.MobileAds;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public abstract class BaseBottomNavActivity extends AppCompatActivity {
 
     protected BottomNavigationView bottomNavigationView;
+
+    // Central AdView reference for activities that include bottom_tool_bar
+    private AdView adView;
+    private boolean adLoaded = false;
 
     /**
      * Return the menu id that should be selected for this activity (eg R.id.songLibraryButton)
@@ -23,6 +33,12 @@ public abstract class BaseBottomNavActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        // Initialize Mobile Ads SDK once for the app. Safe to call multiple times.
+        try {
+            MobileAds.initialize(this, initializationStatus -> { /* no-op */ });
+        } catch (Exception e) {
+            Log.w("BaseBottomNavActivity", "MobileAds.initialize failed", e);
+        }
         // child activities will call setContentView and may have the bottom nav in their layout
     }
 
@@ -41,6 +57,50 @@ public abstract class BaseBottomNavActivity extends AppCompatActivity {
                 }
             }
         } catch (Exception ignored) {}
+
+        // For MusicPlayerActivity, do not show the bottom banner ad.
+        // Hide the AdView (if present) and ensure the BottomNavigationView aligns to parent bottom.
+        try {
+            if (this instanceof MusicPlayerActivity) {
+                adView = findViewById(com.example.tempo.R.id.adView);
+                if (adView != null) {
+                    try { adView.setVisibility(android.view.View.GONE); } catch (Exception ignored) {}
+                }
+                BottomNavigationView bottom = findViewById(com.example.tempo.R.id.bottomToolBar);
+                if (bottom != null) {
+                    ViewGroup.LayoutParams lp = bottom.getLayoutParams();
+                    if (lp instanceof RelativeLayout.LayoutParams) {
+                        RelativeLayout.LayoutParams rlp = (RelativeLayout.LayoutParams) lp;
+                        try {
+                            // Remove the "above adView" rule and align parent bottom so nav isn't squished
+                            rlp.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+                            // removeRule is API 17+. Attempt to remove if available.
+                            try { rlp.removeRule(RelativeLayout.ABOVE); } catch (NoSuchMethodError ignored) {}
+                        } catch (Exception ignored) {}
+                        bottom.setLayoutParams(rlp);
+                    }
+                }
+                return;
+            }
+        } catch (Exception e) {
+            Log.w("BaseBottomNavActivity", "Skipping banner for MusicPlayerActivity failed", e);
+        }
+
+        // Find AdView (if present in this activity's layout) and load/resume it
+        try {
+            adView = findViewById(com.example.tempo.R.id.adView);
+            if (adView != null) {
+                // Load ad only once per activity instance
+                if (!adLoaded) {
+                    AdRequest adRequest = new AdRequest.Builder().build();
+                    try { adView.loadAd(adRequest); } catch (Exception e) { Log.w("BaseBottomNavActivity", "adView.loadAd failed", e); }
+                    adLoaded = true;
+                }
+                try { adView.resume(); } catch (Exception ignored) {}
+            }
+        } catch (Exception e) {
+            Log.w("BaseBottomNavActivity", "AdView setup failed", e);
+        }
     }
 
     @Override
@@ -60,6 +120,25 @@ public abstract class BaseBottomNavActivity extends AppCompatActivity {
                         }
                     } catch (Exception ignored) {}
                 }, 60);
+            }
+        } catch (Exception ignored) {}
+
+        // Pause ad view if exists
+        try {
+            if (adView != null) {
+                adView.pause();
+            }
+        } catch (Exception ignored) {}
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        // Destroy ad view
+        try {
+            if (adView != null) {
+                adView.destroy();
+                adView = null;
             }
         } catch (Exception ignored) {}
     }

--- a/app/src/main/java/com/example/tempo/ui/BottomToolbarActivity.java
+++ b/app/src/main/java/com/example/tempo/ui/BottomToolbarActivity.java
@@ -7,34 +7,19 @@ import android.os.Bundle;
 import android.view.MenuItem;
 import android.widget.Toast;
 
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.AdView;
-import com.google.android.gms.ads.MobileAds;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.navigation.NavigationBarView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 
 public class BottomToolbarActivity extends BaseBottomNavActivity {
     // Use the shared player reference from MainActivity so nav checks are consistent
-
-    private AdView adView;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(com.example.tempo.R.layout.bottom_tool_bar);
-
-        new Thread(
-                () -> {
-                    MobileAds.initialize(this, initializationStatus -> {});
-                })
-                .start();
-        adView = findViewById(com.example.tempo.R.id.adView);
-        AdRequest adRequest = new AdRequest.Builder().build();
-        adView.loadAd(adRequest);
 
         BottomNavigationView bottomNavigationView=findViewById(com.example.tempo.R.id.bottomToolBar);
 

--- a/app/src/main/java/com/example/tempo/ui/LyricsActivity.java
+++ b/app/src/main/java/com/example/tempo/ui/LyricsActivity.java
@@ -37,6 +37,7 @@ import android.content.IntentFilter;
 import android.os.SystemClock;
 import android.view.Gravity;
 import android.view.ViewGroup;
+import com.example.tempo.util.AdManager;
 
 public class LyricsActivity extends BaseBottomNavActivity {
      TextView lyricsPlainText;
@@ -1121,5 +1122,19 @@ public class LyricsActivity extends BaseBottomNavActivity {
     protected int getNavigationItemId() {
         // Lyrics screen isn't directly represented in bottom nav; return 0 to avoid selecting any item
         return 0;
+    }
+
+    @Override
+    public void onBackPressed() {
+        // Suppress a subsequent interstitial when returning to the Music Player
+        try { AdManager.suppressNextInterstitial(this); } catch (Exception ignored) {}
+        super.onBackPressed();
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        try { AdManager.suppressNextInterstitial(this); } catch (Exception ignored) {}
+        finish();
+        return true;
     }
 }

--- a/app/src/main/java/com/example/tempo/ui/MainActivity.java
+++ b/app/src/main/java/com/example/tempo/ui/MainActivity.java
@@ -28,7 +28,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
@@ -36,6 +35,9 @@ import androidx.core.content.ContextCompat;
 
 import com.example.tempo.Services.OnClearRecentService;
 import com.example.tempo.Services.MediaPlaybackService;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.MobileAds;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import com.karumi.dexter.Dexter;
@@ -78,6 +80,9 @@ public class MainActivity extends BaseBottomNavActivity implements com.example.t
     MediaBrowserCompat mediaBrowser; // for mini-bar live updates
     private boolean skipShowAnimation = false;
 
+    // AdView reference
+    private AdView adView;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -91,6 +96,20 @@ public class MainActivity extends BaseBottomNavActivity implements com.example.t
             createChannel();
             // clear-recent service (keeps app from restarting unexpectedly)
             startService(new Intent(getBaseContext(), OnClearRecentService.class));
+        }
+
+        MobileAds.initialize(this, initializationStatus -> { /* no-op */ });
+
+        // Find AdView and load an ad
+        try {
+            adView = findViewById(com.example.tempo.R.id.adView);
+            if (adView != null) {
+
+                AdRequest adRequest = new AdRequest.Builder().build();
+                adView.loadAd(adRequest);
+            }
+        } catch (Exception e) {
+            Log.e("MainActivity", "Failed to load AdView", e);
         }
 
         Toolbar toolbar = findViewById(com.example.tempo.R.id.tempoToolBar);
@@ -567,6 +586,13 @@ public class MainActivity extends BaseBottomNavActivity implements com.example.t
                 mediaBrowser = null;
             }
         } catch (Exception ignored) {}
+
+        // Destroy ad view
+        if (adView != null) {
+            try {
+                adView.destroy();
+            } catch (Exception ignored) {}
+        }
     }
 
 
@@ -596,6 +622,20 @@ public class MainActivity extends BaseBottomNavActivity implements com.example.t
             nowPlayingTitle.setVisibility(View.GONE);
             nowPlayingClickable.setVisibility(View.GONE);
         }
+
+        // Resume ad view
+        if (adView != null) {
+            adView.resume();
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        // Pause ad view
+        if (adView != null) {
+            adView.pause();
+        }
+        super.onPause();
     }
 
     @Override

--- a/app/src/main/java/com/example/tempo/util/AdManager.java
+++ b/app/src/main/java/com/example/tempo/util/AdManager.java
@@ -1,0 +1,59 @@
+package com.example.tempo.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class AdManager {
+    private static final String PREFS = "ad_prefs";
+    private static final String KEY_LAST_INTERSTITIAL = "last_interstitial_shown_ms";
+    private static final String KEY_SUPPRESS_NEXT = "suppress_next_interstitial";
+    // Cooldown between interstitials (5 minutes default)
+    private static final long DEFAULT_COOLDOWN_MS = 5 * 60 * 1000L;
+
+    // Allow override for tests or future configuration
+    public static boolean shouldShowInterstitial(Context ctx) {
+        return shouldShowInterstitial(ctx, DEFAULT_COOLDOWN_MS);
+    }
+
+    public static synchronized boolean shouldShowInterstitial(Context ctx, long cooldownMs) {
+        try {
+            // If a one-time suppression flag is set, do not show and clear it
+            if (consumeSuppressFlag(ctx)) return false;
+
+            SharedPreferences sp = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+            long last = sp.getLong(KEY_LAST_INTERSTITIAL, 0L);
+            long now = System.currentTimeMillis();
+            return now - last >= cooldownMs;
+        } catch (Exception e) {
+            // If anything goes wrong, be conservative and allow showing
+            return true;
+        }
+    }
+
+    public static synchronized void markInterstitialShown(Context ctx) {
+        try {
+            SharedPreferences sp = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+            sp.edit().putLong(KEY_LAST_INTERSTITIAL, System.currentTimeMillis()).apply();
+        } catch (Exception ignored) {}
+    }
+
+    // Request that the next interstitial be suppressed once. Use this when launching an activity
+    // that will immediately return to the MusicPlayer (e.g. LyricsActivity) so the ad doesn't reappear.
+    public static synchronized void suppressNextInterstitial(Context ctx) {
+        try {
+            SharedPreferences sp = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+            sp.edit().putBoolean(KEY_SUPPRESS_NEXT, true).apply();
+        } catch (Exception ignored) {}
+    }
+
+    // Consume the suppression flag (returns true if suppression was set and clears it).
+    public static synchronized boolean consumeSuppressFlag(Context ctx) {
+        try {
+            SharedPreferences sp = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+            boolean v = sp.getBoolean(KEY_SUPPRESS_NEXT, false);
+            if (v) sp.edit().remove(KEY_SUPPRESS_NEXT).apply();
+            return v;
+        } catch (Exception ignored) {}
+        return false;
+    }
+}

--- a/app/src/main/res/layout/bottom_tool_bar.xml
+++ b/app/src/main/res/layout/bottom_tool_bar.xml
@@ -17,15 +17,12 @@
 
     </FrameLayout>
 
-    <com.google.android.gms.ads.AdView
-        android:id="@+id/adView"
+    <include
+        android:id="@+id/nowPlayingInclude"
+        layout="@layout/now_playing_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_above="@id/bottomToolBar"
-        app:adSize="BANNER"
-        app:adUnitId="ca-app-pub-5675914922459331/2458838497"
-        tools:ignore="MissingConstraints"/>
+        android:layout_height="56dp"
+        android:layout_above="@id/bottomToolBar" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:background="@color/black"
@@ -33,13 +30,18 @@
         android:layout_width="match_parent"
         android:layout_height="56dp"
         style="@style/Widget.MaterialComponents.BottomNavigationView.Colored"
-        android:layout_alignParentBottom="true"
+        android:layout_above="@id/adView"
         app:menu="@menu/bottomtoolbarmenu"/>
 
-    <include
-        android:id="@+id/nowPlayingInclude"
-        layout="@layout/now_playing_bar"
+    <com.google.android.gms.ads.AdView
+        android:id="@+id/adView"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:layout_above="@id/bottomToolBar" />
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        app:adSize="BANNER"
+        app:adUnitId="ca-app-pub-3940256099942544/9214589741"
+        tools:ignore="MissingConstraints"/>
+<!--    Test Ad Unit Id   -->
+
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,7 @@
     <string name="lyrics_not_found">Lyrics not found. Try again later.</string>
     <string name="lyrics_updated">Lyrics updated</string>
     <string name="lyrics_up_to_date">Lyrics are up to date</string>
+
+    <!-- Interstitial ad unit id for MusicPlayerActivity. Test ad unit ID -->
+    <string name="music_player_interstitial_ad_unit_id">ca-app-pub-3940256099942544/1033173712</string>
 </resources>


### PR DESCRIPTION
## Description
This PR corrects the previously broken implementation of ads in the app, specifically banner ads and an interstitial ad. For now these ads use the testing ad ID until the app store release.

## Related Issue

N/A

## What I changed
- Addition of /util/ folder for modules such as the Ad Manager
- Implementation of banner ads and interstitial ads.

## Screenshots / Recording

N/A

## Checklist
- [x] I ran the app and verified the change on emulator/device
- [ ] I ran unit tests and lint
- [ ] I updated relevant documentation (README or in-code comments)
- [x] No unrelated files included in this PR
